### PR TITLE
fix: refactor segmentize approach

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -105,3 +105,4 @@ segmentizing
 formatcp
 opstatus
 isas
+AETH

--- a/client-grpc/examples/grpc.rs
+++ b/client-grpc/examples/grpc.rs
@@ -361,9 +361,6 @@ async fn best_path_flight_avoidance(
 
     let _ = client.update_flight_path(request).await?.into_inner();
 
-    // Might take a moment for the flight to be consumed from the queue by svc-gis
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
     // Best Path Request
     println!("\n\u{1F426} Best Path With Prior Flight Path @ Different Altitude (No-Intersect)");
     let request = BestPathRequest {
@@ -400,8 +397,8 @@ async fn best_path_flight_avoidance(
     .collect::<Vec<PointZ>>();
 
     let request = UpdateFlightPathRequest {
-        flight_identifier: Some("FLIGHT-X".to_string()),
-        aircraft_identifier: Some("Fondor".to_string()),
+        flight_identifier: Some("AETH12345".to_string()),
+        aircraft_identifier: Some("AETH-CRAFT-X".to_string()),
         path,
         timestamp_start: Some(time_start.into()),
         timestamp_end: Some(time_end.into()),
@@ -410,9 +407,6 @@ async fn best_path_flight_avoidance(
     };
 
     let _ = client.update_flight_path(request).await?.into_inner();
-
-    // Might take a moment for the flight to be consumed from the queue by svc-gis
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
     //
     // Try Best Path again during same time as other flight, should be none
@@ -721,11 +715,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     add_aircraft(&mut connection).await.unwrap();
     add_flight_paths(&client).await.unwrap();
-
-    // might take a moment for the flight paths to
-    //  be picked up from the redis queue
     std::thread::sleep(std::time::Duration::from_secs(1));
-
     get_flights(&client).await?;
     add_vertiports(&client).await?;
     add_waypoints(&client).await?;


### PR DESCRIPTION
Removed the "flight_segments" table as it was horribly inefficient. One trip at the large scale was storing several thousand segments.

Now if there's any intersection with the whole flight paths, I segmentize both flight paths into two halves each, and only compare the segments that overlap in time. If two of the segments overlap, I chop just those segments into two again, and continue comparing until we're down to the minimum allowed distance.

![Untitled-2024-03-30-2029](https://github.com/aetheric-oss/svc-gis/assets/6334638/54e86376-1205-4cde-b5e9-f1b4ede40143)

In the best case we learn with just one subdivision that the two paths won't intersect in time:
<img width="1234" alt="image" src="https://github.com/aetheric-oss/svc-gis/assets/6334638/79c47f6b-2c48-4a32-98d0-eb0ce3f87e1c">


